### PR TITLE
Add config for delay between requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# v1.1.0
+**Date:** 2023/03/18
+
+### New features
+
+* Added a configuration option to set a delay between consecutive requests ([#1](https://github.com/jreyesr/insomnia-plugin-batch-requests/issues/1))
+
+# v1.0.1
+**Date:** 2023/02/19
+
+Initial version
+
+# v1.0.0
+**Date:** 2023/02/18
+
+~~Initial version~~
+
+Pulled from NPM because of missing main file.

--- a/README.md
+++ b/README.md
@@ -42,3 +42,18 @@ On the plugin dialog (see the image below), you should:
 5. Click the `Save` button to write the extracted data back to the CSV file, if you need it.
 
 ![A screenshot showing the main plugin UI. From top to bottom, there is a button to load a file, a table showing a preview of the data, a series of fields to specify output data, and a button to run the request multiple times](images/runner_ui.png)
+
+## Development
+
+1. Identify your Insomnia plugin folder. On Ubuntu, it should be `~/.config/Insomnia/plugins`. Alternatively, open Insomnia, select the `Application>Preferences` menu, go to the Plugins tab, then click the `Reveal Plugins Folder` button.
+2. On that folder, run `git clone https://github.com/jreyesr/insomnia-plugin-batch-requests`.
+3. Run `npm i`.
+3. Run `npm run dev`. This will start a dev server that will generate the `dist/main.js` file and keep it updated whenever you change the source files.
+4. Open the Insomnia Plugins dialog (see the first step). It should display the plugin, since it's in the correct folder. It's not necessary to manually install it.
+5. Create and checkout a new branch.
+6. Hackity hack on the source files.
+7. Whenever you save a file, the `dist/main.js` file will be updated. To make Insomnia pick up the changes, select the `Tools>Reload plugins` option from the top menus. Alternatively, press `Alt+T`, then release both, then press `R`.
+8. Make commit.
+9. GOTO 6
+10. Update the package version in `package.json`.
+11. When done, submit a PR and merge it. The CD should pick it up, compile a package and upload it to NPM.

--- a/components/BatchDialog.js
+++ b/components/BatchDialog.js
@@ -10,6 +10,7 @@ import FileChooserButton from './FileChooserButton';
 import ActionButton from './ActionButton';
 import OutputFieldsChooser from './OutputFieldsChooser';
 import ProgressBar from './ProgressBar';
+import DelaySelector from './DelaySelector';
 
 export default function BatchDialog({context, request}) {
   const [csvPath, setCsvPath] = useState("");
@@ -17,6 +18,7 @@ export default function BatchDialog({context, request}) {
   const [csvData, setCsvData] = useState([]);
   const [outputConfig, setOutputConfig] = useState([]);
   const [sent, setSent] = useState(0);
+  const [delay, setDelay] = useState(0);
 
   const onFileChosen = (path => {
     setCsvPath(path);
@@ -42,6 +44,11 @@ export default function BatchDialog({context, request}) {
       await context.store.removeItem(storeKey);
       setSent(s => s + 1);
       console.debug(response);
+
+      // Sleep for a bit
+      console.debug("sleep started, delay =", delay)
+      await new Promise(r => setTimeout(r, delay * 1000));
+      console.debug("sleep ended")
 
       // If we need to extract response data, check that the Content-Type header is sensible, otherwise error out
       if(outputConfig.length > 0 && !response.contentType.startsWith("application/json")) {
@@ -75,6 +82,11 @@ export default function BatchDialog({context, request}) {
     setOutputConfig(x)
   }
 
+  const onChangeDelay = ({target: {value}}) => {
+    if(value < 0) return;
+    setDelay(value)
+  }
+
   return (<React.Fragment>
     <FormRow label="Choose CSV">
       <FileChooserButton onChange={onFileChosen} extensions={["csv"]}/>
@@ -86,6 +98,11 @@ export default function BatchDialog({context, request}) {
     ) : <p>Choose a file above to preview it!</p>}
 
     <OutputFieldsChooser colNames={csvHeaders} onChange={onChangeOutputFields} />
+
+    <FormRow label="Run config">
+      <DelaySelector value={delay} onChange={onChangeDelay}/>
+    </FormRow>
+
     <FormRow label="Progress">
       <ProgressBar bgcolor="#a11" completed={sent * 100 / totalRequests} text={`${sent}/${totalRequests}`} />
     </FormRow>

--- a/components/DelaySelector.js
+++ b/components/DelaySelector.js
@@ -1,0 +1,11 @@
+export default function DelaySelector({value, onChange}) {
+  return <label>
+    Delay in seconds
+    <input
+      type="number"
+      step="0.1"
+      value={value}
+      onChange={onChange}
+    />
+  </label>
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "insomnia-plugin-batch-requests",
-  "version": "0.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "insomnia-plugin-batch-requests",
-      "version": "0.0.1",
+      "version": "1.1.0",
+      "license": "MIT",
       "dependencies": {
         "csv-stringify": "^6.2.4",
         "csvtojson": "^2.0.10",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": {
     "url": "https://github.com/jreyesr/insomnia-plugin-batch-requests"
   },
-  "version": "1.0.1",
+  "version": "1.1.0",
   "author": {
     "name": "jreyesr",
     "url": "https://github.com/jreyesr"


### PR DESCRIPTION
This PR adds a new configuration option to set a delay between consecutive requests, as requested by @dotJson on issue #1.

Primary usecase is to avoid rate limiting on APIs that are slow/resource constrained or have strict rate limits. Also to increase feature coverage as compared to Postman Test Runner, which does have this function.

![image](https://user-images.githubusercontent.com/23390438/226151426-4ad24aa5-9134-40d1-abfc-f7985ef79ba6.png)

Closes #1